### PR TITLE
Makefile command documentation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,9 +7,9 @@ Possible ideas for future versions
 - the @roles_list is implemented badly, do a get query first before the check for existance when adding a role to a user
 - Break out the code into a separate library and create an API to access etc
 - Configure bot via config file or via command to set admins/curators
-- Integrate with social media, Tumblr/Twitter/Minds/Fediverse/Instagram/Pinterest maybe to find pictures or posts of interest to the various room topics.
+- Integrate with social media, Reddit/Tumblr/Twitter/Minds/Fediverse/Instagram/Pinterest maybe to find pictures or posts of interest to the various room topics.
 - Eventually release the bot to allow it to be invited to multiple servers, and run simulataneously.
-- figure out how to have users authenticate with their own api keys rather than using mine when posting to a gab group
+- figure out how to have users authenticate with their own api keys rather than using mine when posting to a gab group/other social media etc
 
 
 === 0.0.7

--- a/Makefile
+++ b/Makefile
@@ -7,25 +7,27 @@ PKG=github.com/davidkirwan/makerculture
 PWD=$(shell pwd)
 DISCORD_TOKEN=$(shell cat discord_token.txt)
 
-.PHONY: default
-default: list
+.DEFAULT_GOAL:=help
 
-.PHONY: list
-list:
-	@echo --- Printing targets: ---
-	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' -e "list" -e "default"
-	@echo --- Printing Complete ---
+.PHONY: help
+help: ## Show this help screen
+	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
+	@echo ''
+	@echo 'Available targets are:'
+	@echo ''
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
+##@ Image
 
-.PHONY: image/build
-image/build:
+.PHONY: build
+build: ## Build the image
 	podman image build -t "${REG}/${ORG}/${PROJECT}:${TAG}" .
 
-.PHONY: image/push
-image/push:
+.PHONY: push
+push: ## Push the image to quay.io
 	podman push ${REG}/${ORG}/${PROJECT}:${TAG}
 
 .PHONY: run
-run:
+run: ## Run the container
 	podman run --rm -it -p 0.0.0.0:3000:3000 -v $(PWD):/root/src --name makerculture ${REG}/${ORG}/${PROJECT}:${TAG} $(DISCORD_TOKEN)
 


### PR DESCRIPTION
Updated the `Makefile` targets with some documentation annotations which are used to build up the help information for the new default make target `help`.

Considering trying to integrate the bot with Reddit. Have a new subreddit I hope to be able to cross post content from Discord/Reddit to each other and target hashtags/topics/rooms.